### PR TITLE
fix: modify matching of undefined values

### DIFF
--- a/currentScript.js
+++ b/currentScript.js
@@ -22,7 +22,7 @@
 
           // For all scripts on the page, if src matches or if ready state is interactive, return the script tag
           for(i in scripts){
-            if(scripts[i].src == res || scripts[i].readyState == "interactive"){
+            if(res && scripts[i].src == res || scripts[i].readyState == "interactive"){
               return scripts[i];
             }
           }


### PR DESCRIPTION
`for in` traverses the length attribute of the array, causes matching of undefined values and return the Array's length.